### PR TITLE
correct links to server and client examples

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ Curryer is inspired by the now unmaintained [distributed-process](https://hackag
 
 ## Code Example
 
-[Server](https://github.com/agentm/curryer/examples/SimpleKeyValueServer.hs):
+[Server](examples/SimpleKeyValueServer.hs):
 
 ```haskell
 data SetKey = SetKey String String
@@ -41,7 +41,7 @@ kvRequestHandlers = [ RequestHandler $ \state (SetKey k v) ->
                     ]
 ```
 
-[Client](https://github.com/agentm/curryer/examples/SimpleKeyValueClient.hs):
+[Client](examples/SimpleKeyValueClient.hs):
 
 ```haskell
 data SetKey = SetKey String String


### PR DESCRIPTION
Added generic Github link format, which changes based on the fork and branch.
The current links in readme throw a 404.